### PR TITLE
ci: add status badge into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Formiz
+
+![Tests Badge](https://github.com/ivan-dalmet/formiz/workflows/Formiz%20Test/badge.svg)
+
 React multi steps forms with full validations
 
 👩‍🔬 This is an early and alpha release of Formiz. API is subject to change. Do not use in production.


### PR DESCRIPTION
As seen in https://twitter.com/mscccc/status/1170437608897269760?s=20 the new GitHub Actions status badge is live:

<blockquote class="twitter-tweet"><p lang="en" dir="ltr">ohh heeyy<br><br>the official <a href="https://twitter.com/github?ref_src=twsrc%5Etfw">@github</a> Actions status badges just landed in the docs.<a href="https://t.co/z6RBb83JQM">https://t.co/z6RBb83JQM</a><br><br>design by <a href="https://twitter.com/jasonlong?ref_src=twsrc%5Etfw">@jasonlong</a>, code by <a href="https://twitter.com/mxie?ref_src=twsrc%5Etfw">@mxie</a> <a href="https://t.co/g7PONjVa4f">pic.twitter.com/g7PONjVa4f</a></p>&mdash; Mike Coutermarsh (@mscccc) <a href="https://twitter.com/mscccc/status/1170437608897269760?ref_src=twsrc%5Etfw">September 7, 2019</a></blockquote>

For more information about the new status badge feature for GitHub Actions, checkout the following documentation:

https://help.github.com/en/articles/configuring-a-workflow#adding-a-workflow-status-badge-to-your-repository

Hope you'll enjoy this new badge as I do.

![image](https://render.bitstrips.com/v2/cpanel/5988aada-93ab-4f3b-9dda-a5cfdafc310c-28509fbe-5dd0-4c1e-9b9f-5043673dc433-v1.png?transparent=1&palette=1)

