### PR TITLE
fix: typo in getting started code sample

### DIFF
--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -49,7 +49,7 @@ import { useField } from '@formiz/core'
 
 export const MyField = () => {
   // ...
-});
+};
 ```
 
 #### 2. Pass props to the hook
@@ -65,7 +65,7 @@ import { useField } from '@formiz/core'
 export const MyField = (props) => {
   const {} = useField(props); // Pass the props to the hook
   // ...
-});
+};
 ```
 
 #### 3. Make it works
@@ -86,7 +86,7 @@ export const MyField = (props) => {
       onChange={e => setValue(e.target.value)} // Update the value onChange
     />
   );
-});
+};
 ```
 
 #### 3. Display error
@@ -113,7 +113,7 @@ export const MyField = (props) => {
       }
     </div>
   );
-});
+};
 ```
 
 #### 4. Improve UX and accessibility


### PR DESCRIPTION
![](https://render.bitstrips.com/v2/cpanel/2af24209-ea90-4912-9223-4c54c650559a-28509fbe-5dd0-4c1e-9b9f-5043673dc433-v1.png?transparent=1&palette=1)

I love bracket too, but there is too much of them in the doc 😛 