### PR TITLE
docs(README): update link to netlify

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Visit [formiz-react.com](https://formiz-react.com) for [full documentation](http
 
 Visit documentation for [live demos](https://formiz-react.com/docs/demos/wizard).
 
-Visit [formiz-examples.netlify.com](https://formiz-examples.netlify.com) for examples with [Chakra UI](https://chakra-ui.com/).
+Visit [formiz-examples.netlify.app](https://formiz-examples.netlify.app) for examples with [Chakra UI](https://chakra-ui.com/).
 
 ## Concept
 

--- a/docs/docs/demos/other-examples.mdx
+++ b/docs/docs/demos/other-examples.mdx
@@ -3,12 +3,12 @@ id: other-examples
 title: Other examples
 ---
 
-Visit **[Formiz Examples website](https://formiz-examples.netlify.com/)** to see examples built with [Chakra UI](https://chakra-ui.com/).<br />
+Visit **[Formiz Examples website](https://formiz-examples.netlify.app/)** to see examples built with [Chakra UI](https://chakra-ui.com/).<br />
 You can [view the code](https://github.com/ivan-dalmet/formiz/tree/master/examples) of the Formiz Examples website on [Github](https://github.com/ivan-dalmet/formiz/tree/master/examples).
 
 <a
   class="button button--primary button--lg"
-  href="https://formiz-examples.netlify.com/"
+  href="https://formiz-examples.netlify.app/"
   target="_blank"
 >
   Formiz Examples


### PR DESCRIPTION
Nothing is broken by the Netlify migration from `.com` to `.app`, but it will be the new "convention", so I just made the change in the README atm.

More information on [Netlify Community Website](https://community.netlify.com/t/changes-coming-to-netlify-site-urls/8918)