### PR TITLE
New flatValues object from useForm() hook 

### DIFF
--- a/documentation/docs/core/useForm-hook.mdx
+++ b/documentation/docs/core/useForm-hook.mdx
@@ -390,10 +390,39 @@ myForm.isLastStep // true or false
 
 ### values
 
-Returns an object with all the values of the form.<br />
+Returns an object with all the values of the form **with nested values**.<br />
 See [the `name` props for fields](/docs/core/use-field#name-) for nested objects and array values.
 
 ```jsx
 const myForm = useForm()
-myForm.values // { fieldA: 'field A value', fieldB: 'field B value' }
+myForm.values
+/*
+{
+  fieldA: 'field A value',
+  nested: {
+    fieldB: 'field B value',
+  },
+  collection: [
+    { field: 'collection first value' },
+    { field: 'collection second value' },
+  ],
+}
+*/
+```
+
+### flatValues
+
+Returns an object with all the values of the form **without nested values**.
+
+```jsx
+const myForm = useForm()
+myForm.flatValues
+/*
+{
+  fieldA: 'field A value',
+  'nested.fieldB': 'field B value',
+  'collection[0].field': 'collection first value',
+  'collection[1].field': 'collection second value',
+}
+*/
 ```

--- a/packages/core/src/useForm.ts
+++ b/packages/core/src/useForm.ts
@@ -6,7 +6,7 @@ import {
   defaultFormState,
   useFormContext,
 } from './Formiz';
-import { getFormValues, useRefValue } from './utils';
+import { getFormValues, getFormFlatValues, useRefValue } from './utils';
 import {
   FormFields,
   UseFormProps,
@@ -143,6 +143,7 @@ export const useForm = ({
     } : {}),
     ...(shouldSubscribe(subscribe, 'fields') ? {
       values: getFormValues(localFields),
+      flatValues: getFormFlatValues(localFields),
     } : {}),
     __connect__: connect,
   };

--- a/packages/core/src/utils/form.utils.ts
+++ b/packages/core/src/utils/form.utils.ts
@@ -63,3 +63,10 @@ export const getFormValues = (fields: FormFields) => {
 
   return parseValues(values);
 };
+
+export const getFormFlatValues = (fields: FormFields) => (fields || [])
+  .filter((field) => field.isEnabled)
+  .reduce((obj, field) => ({
+    ...obj,
+    [field.name]: field.value,
+  }), {});

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,4 +1,4 @@
-export { getFormValues } from './form.utils';
+export { getFormValues, getFormFlatValues } from './form.utils';
 export { getFormUniqueId, getFieldUniqueId, getFieldHtmlUniqueId } from './global.utils';
 export { useRefValue } from './useRefValue';
 export { useSubject, useBehaviorSubject } from './useSubject';


### PR DESCRIPTION
## New flatValues object for `useForm` (#37)

Returns an object with all the values of the form without nested values.

```js
const myForm = useForm()
myForm.flatValues
/*
{
  fieldA: 'field A value',
  'nested.fieldB': 'field B value',
  'collection[0].field': 'collection first value',
  'collection[1].field': 'collection second value',
}
*/
```
