### PR TITLE
fix: Examples contain tiny typo issues

### DIFF
--- a/documentation/docs/core/useForm-hook.mdx
+++ b/documentation/docs/core/useForm-hook.mdx
@@ -339,7 +339,7 @@ Returns true if all the fields are pristine on the current step.
 
 ```jsx
 const myForm = useForm()
-myForm.isStepValid // true or false
+myForm.isStepPristine // true or false
 ```
 
 
@@ -358,7 +358,7 @@ Returns true if one field or more is running async validations on the current st
 
 ```jsx
 const myForm = useForm()
-myForm.isStepValid // true or false
+myForm.isStepValidating // true or false
 ```
 
 ### isStepSubmitted


### PR DESCRIPTION
Before :  
![image](https://user-images.githubusercontent.com/50022361/115200228-454bec00-a0f4-11eb-85de-d557b1406e2d.png)  
---
After :  
![image](https://user-images.githubusercontent.com/50022361/115200283-54329e80-a0f4-11eb-81a3-0d3d52166be0.png)
