### PR TITLE
feat: Allows setValue to accept a function with the previous value

### DIFF
--- a/documentation/docs/core/useField-hook.mdx
+++ b/documentation/docs/core/useField-hook.mdx
@@ -44,6 +44,17 @@ const MyField = (props) => {
 }
 ```
 
+`setValue` also accept a function that gives the previous value (like React `setState`).
+
+```jsx
+setValue((previousValue) => {
+  // ...
+  // Your logic
+  // ...
+  return newValue;
+})
+```
+
 ---
 
 ## Hook values

--- a/packages/core/src/types/field.types.ts
+++ b/packages/core/src/types/field.types.ts
@@ -102,6 +102,6 @@ export interface ExposedField {
 }
 
 export interface UseFieldValues extends ExposedField {
-  setValue(value: FieldValue): void;
+  setValue(value: FieldValue | ((prevValue: FieldValue) => FieldValue)): void;
   otherProps: any;
 }

--- a/packages/core/src/useField.ts
+++ b/packages/core/src/useField.ts
@@ -103,15 +103,19 @@ export const useField = ({
   const defaultValueRef = useRefValue(defaultValue);
   const keepValueRef = useRefValue(keepValue);
 
-  const setValue = useCallback((value: FieldValue) => {
-    setState((prevState: FieldState) => ({
-      ...prevState,
-      externalErrors: [],
-      value,
-      isPristine: false,
-    }));
-    onChangeRef.current(formatValueRef.current(value), value);
-  }, [onChangeRef, formatValueRef]);
+  const setValue = useCallback(
+    (value: FieldValue | ((prevValue: FieldValue) => FieldValue)) => {
+      const computedValue = typeof value === 'function' ? value(stateRef?.current?.value) : value;
+      setState((prevState: FieldState) => ({
+        ...prevState,
+        externalErrors: [],
+        value: computedValue,
+        isPristine: false,
+      }));
+      onChangeRef.current(formatValueRef.current(computedValue), computedValue);
+    },
+    [onChangeRef, formatValueRef, stateRef],
+  );
 
   // Subscribe to form state
   useEffect(() => {

--- a/packages/core/test/useField/useField.setValue.test.ts
+++ b/packages/core/test/useField/useField.setValue.test.ts
@@ -22,4 +22,13 @@ describe('useField: setValue', () => {
     object: { newValue: { a: 1, b: 2, c: 3 } },
     'empty object': { newValue: {} },
   });
+
+  it('useField: setValue with function', async () => {
+    const { act, result, formValues } = renderUseField({ name: 'field1', defaultValue: 'previousValue' });
+    await act(() => {
+      result.current.setValue((previousValue: any) => `${previousValue}+NewValue`);
+    });
+    expect(result.current.value).toStrictEqual('previousValue+NewValue');
+    expect(formValues.current).toHaveProperty('field1', 'previousValue+NewValue');
+  });
 });


### PR DESCRIPTION
Allows `setValue` to accept a function that gives the previous value (like React `setState`).

```jsx
setValue((previousValue) => {
  // ...
  // Your logic
  // ...
  return newValue;
})
```