### PR TITLE
refactor: replace wait with waitFor

### DIFF
--- a/packages/core/test/useField/useField.isValid.test.ts
+++ b/packages/core/test/useField/useField.isValid.test.ts
@@ -9,7 +9,7 @@ describe('useField: isValid', () => {
   });
 
   it('Should be invalid if one sync validation is false', async () => {
-    const { result, wait } = renderUseField({
+    const { result, waitFor } = renderUseField({
       name: 'field1',
       validations: [
         {
@@ -17,11 +17,11 @@ describe('useField: isValid', () => {
         },
       ],
     });
-    await wait(() => expect(result.current.isValid).toBe(false));
+    await waitFor(() => expect(result.current.isValid).toBe(false));
   });
 
   it('Should be invalid if one async validation is false', async () => {
-    const { result, wait } = renderUseField({
+    const { result, waitFor } = renderUseField({
       name: 'field1',
       asyncValidations: [
         {
@@ -29,6 +29,6 @@ describe('useField: isValid', () => {
         },
       ],
     });
-    await wait(() => expect(result.current.isValid).toBe(false));
+    await waitFor(() => expect(result.current.isValid).toBe(false));
   });
 });


### PR DESCRIPTION
wait is deprecated (use https://react-hooks-testing-library.com/reference/api#waitfor)

# Before

![image](https://user-images.githubusercontent.com/3920615/129066799-9dcf3385-e270-4a57-ac18-c0353220ef30.png)

# After

![image](https://user-images.githubusercontent.com/3920615/129066763-35224ea7-e158-4858-b122-b599ab722cda.png)

