### PR TITLE
feat: allows subscribe to objets and arrays

### DIFF
--- a/packages/core/src/useForm.ts
+++ b/packages/core/src/useForm.ts
@@ -75,7 +75,7 @@ export const useForm = ({
       const subscription = subject.subscription.subscribe(
         (nextFields: FormFields) => {
           const nextState = subscribeFields
-            ? nextFields.filter((x) => subscribeFields.includes(x.name))
+            ? nextFields.filter((x) => subscribeFields.some((name) => name === x.name || x.name.startsWith(`${name}[`) || x.name.startsWith(`${name}.`)))
             : nextFields;
 
           if (JSON.stringify(localFieldsRef.current) === JSON.stringify(nextState)) {

--- a/packages/core/test/useForm.test.tsx
+++ b/packages/core/test/useForm.test.tsx
@@ -8,17 +8,119 @@ describe('useForm: Mount', () => {
   });
 
   it('Should be invalid if a least one field is invalid', async () => {
-    const { result, waitForNextUpdate } = renderUseForm({}, <Field name="field1" validations={[{ rule: (x: any) => !!x }]} />);
-    await waitForNextUpdate(() => expect(result.current.isValid).toBe(false));
+    const { result, waitForNextUpdate } = renderUseForm({}, <Field name="fieldA" validations={[{ rule: (x: any) => !!x }]} />);
+    await waitForNextUpdate();
+    expect(result.current.isValid).toBe(false);
   });
 
   it('Should get the field key in values', async () => {
-    const { result, waitForNextUpdate } = renderUseForm({}, <Field name="field1" />);
-    await waitForNextUpdate(() => expect(result.current.values).toHaveProperty('field1', null));
+    const { result, waitForNextUpdate } = renderUseForm({}, <Field name="fieldA" />);
+    await waitForNextUpdate();
+    expect(result.current.values).toHaveProperty('fieldA', null);
   });
 
   it('Should get the field key and the field default value in values', async () => {
-    const { result, waitForNextUpdate } = renderUseForm({}, <Field name="field1" defaultValue="default value" />);
-    await waitForNextUpdate(() => expect(result.current.values).toHaveProperty('field1', 'default value'));
+    const { result, waitForNextUpdate } = renderUseForm({}, <Field name="fieldA" defaultValue="default value" />);
+    await waitForNextUpdate();
+    expect(result.current.values).toHaveProperty('fieldA', 'default value');
+  });
+
+  it('Should get not subscribed if subscribe is false', async () => {
+    const { result } = renderUseForm({ subscribe: false }, <Field name="fieldA" validations={[{ rule: (x: any) => !!x }]} />);
+    expect(result.current.isValid).toBe(undefined);
+  });
+
+  it('Should get subscribed to form and not values if subscribe is "form"', async () => {
+    const { result, waitForNextUpdate } = renderUseForm({ subscribe: 'form' }, <Field name="fieldA" validations={[{ rule: (x: any) => !!x }]} />);
+    await waitForNextUpdate();
+    expect(result.current.isValid).toBe(false);
+    expect(result.current.values).toBe(undefined);
+  });
+
+  it('Should get subscribed to values and not form if subscribe is "fields"', async () => {
+    const { result, waitForNextUpdate } = renderUseForm({ subscribe: 'fields' }, <Field name="fieldA" validations={[{ rule: (x: any) => !!x }]} />);
+    await waitForNextUpdate();
+    expect(result.current.isValid).toBe(undefined);
+    expect(result.current.values).toHaveProperty('fieldA');
+  });
+
+  it('Should get subscribed to some fields (1)', async () => {
+    const { result, waitForNextUpdate } = renderUseForm(
+      { subscribe: { fields: ['fieldA'] } },
+      <>
+        <Field name="fieldA" />
+        <Field name="fieldB" />
+        <Field name="field.A" />
+        <Field name="field.B" />
+        <Field name="fields[0].A" />
+        <Field name="fields[1].B" />
+      </>,
+    );
+    await waitForNextUpdate();
+    expect(result.current.values).toHaveProperty('fieldA');
+    expect(result.current.values).not.toHaveProperty('fieldB');
+    expect(result.current.values).not.toHaveProperty('field');
+    expect(result.current.values).not.toHaveProperty('fields');
+  });
+
+  it('Should get subscribed to some fields (2)', async () => {
+    const { result, waitForNextUpdate } = renderUseForm(
+      { subscribe: { fields: ['fieldA', 'fieldB'] } },
+      <>
+        <Field name="fieldA" />
+        <Field name="fieldB" />
+        <Field name="field.A" />
+        <Field name="field.B" />
+        <Field name="fields[0].A" />
+        <Field name="fields[1].B" />
+      </>,
+    );
+    await waitForNextUpdate();
+    expect(result.current.values).toHaveProperty('fieldA');
+    expect(result.current.values).toHaveProperty('fieldB');
+    expect(result.current.values).not.toHaveProperty('field');
+    expect(result.current.values).not.toHaveProperty('fields');
+  });
+
+  it('Should get subscribed to some fields (3)', async () => {
+    const { result, waitForNextUpdate } = renderUseForm(
+      { subscribe: { fields: ['field'] } },
+      <>
+        <Field name="fieldA" />
+        <Field name="fieldB" />
+        <Field name="field.A" />
+        <Field name="field.B" />
+        <Field name="fields[0].A" />
+        <Field name="fields[1].B" />
+      </>,
+    );
+    await waitForNextUpdate();
+    expect(result.current.isValid).toBe(undefined);
+    expect(result.current.values).not.toHaveProperty('fieldA');
+    expect(result.current.values).not.toHaveProperty('fieldB');
+    expect(result.current.values.field).toHaveProperty('A');
+    expect(result.current.values.field).toHaveProperty('B');
+    expect(result.current.values).not.toHaveProperty('fields');
+  });
+
+  it('Should get subscribed to some fields (4)', async () => {
+    const { result, waitForNextUpdate } = renderUseForm(
+      { subscribe: { fields: ['fields'] } },
+      <>
+        <Field name="fieldA" />
+        <Field name="fieldB" />
+        <Field name="field.A" />
+        <Field name="field.B" />
+        <Field name="fields[0].A" />
+        <Field name="fields[1].B" />
+      </>,
+    );
+    await waitForNextUpdate();
+    expect(result.current.isValid).toBe(undefined);
+    expect(result.current.values).not.toHaveProperty('fieldA');
+    expect(result.current.values).not.toHaveProperty('fieldB');
+    expect(result.current.values).not.toHaveProperty('field');
+    expect(result.current.values?.fields?.[0]).toHaveProperty('A');
+    expect(result.current.values?.fields?.[1]).toHaveProperty('B');
   });
 });


### PR DESCRIPTION
## Form Example
Imagine the following form:

```jsx
<Formiz>
  <Field name="something.collection[0].name" />
  <Field name="something.collection[1].name" />
</Formiz>
```

## Current Behaviours in 1.3.1

```js
// Working
✅ useForm({ subscribe: { fields: ['something.collection[0].name'] } });

// Not Working
❌ useForm({ subscribe: { fields: ['something.collection[0]'] } }); 
❌ useForm({ subscribe: { fields: ['something.collection'] } }); 
❌ useForm({ subscribe: { fields: ['something'] } }); 
```

## New Behaviours

```js
// Working
✅ useForm({ subscribe: { fields: ['something.collection[0].name'] } }); 
✅ useForm({ subscribe: { fields: ['something.collection[0]'] } }); 
✅ useForm({ subscribe: { fields: ['something.collection'] } }); 
✅ useForm({ subscribe: { fields: ['something'] } }); 
```