### PR TITLE
Feat/reset options

### DIFF
--- a/documentation/docs/core/useForm-hook.mdx
+++ b/documentation/docs/core/useForm-hook.mdx
@@ -298,13 +298,44 @@ form.setFieldsValues(
 )
 ```
 
-### reset()
+### reset(options)
 
 Allows to reset the form with all fields values to their defaultValue.
 
 ```jsx
 const myForm = useForm()
 myForm.reset() // Trigger the form reset
+```
+
+#### Options
+
+Available reset elements for the `only` and `exclude` options.
+```js
+'pristine'    // Reset isPristine state for form, steps & fields
+'submitted'   // Reset isSubmitted state for form, steps & fields
+'validating'  // Reset isValidating state for form, steps & fields
+'resetKey'    // Increment the resetKey
+'currentStep' // Reset the currentStep
+'visited'     // Reset isVisited state for steps
+'values'      // Reset all fields values
+```
+
+##### only
+
+Allows to reset only some elements.
+
+```js
+// Reset only pristine state and submitted state
+form.reset({ only: ['pristine', 'submitted'] });
+```
+
+##### exclude
+
+Allows to prevent reseting some elements.
+
+```js
+// Reset everything except the form values
+form.reset({ exclude: ['values'] });
 ```
 
 ### getFieldStepName(fieldName)

--- a/packages/core/src/Formiz.tsx
+++ b/packages/core/src/Formiz.tsx
@@ -90,7 +90,7 @@ export const Formiz: React.FC<FormizProps> = ({
   const onFormUpdate = useBehaviorSubject(formStateRef);
   const onFieldsUpdate = useBehaviorSubject(fieldsRef);
   const onExternalFieldsUpdate = useSubject(fieldsRef);
-  const onReset = useSubject(formStateRef);
+  const onReset = useSubject();
 
   const checkFormValidity = (): boolean => {
     const isValid = fieldsRef.current
@@ -316,12 +316,12 @@ export const Formiz: React.FC<FormizProps> = ({
     validateForm();
   };
 
-  const reset = (): void => {
+  const reset: FormMethods['reset'] = (resetOptions): void => {
     keepValuesRef.current = {};
     fromSetFieldsValuesRef.current = {};
     initialValuesRef.current = cloneDeep(initialValues);
-    updateFormState(formActions.resetForm(formStateRef.current));
-    onReset.push();
+    updateFormState(formActions.resetForm(formStateRef.current, resetOptions));
+    onReset.push(resetOptions ?? {});
   };
 
   const formMethods: FormMethods = {

--- a/packages/core/src/formActions.ts
+++ b/packages/core/src/formActions.ts
@@ -1,5 +1,6 @@
-import { FormState } from './types/form.types';
+import { FormState, ResetOptions } from './types/form.types';
 import { StepState } from './types/step.types';
+import { isResetAllowed } from './utils';
 
 export const updateStep = (state: FormState, partialStepState: Partial<StepState>): FormState => {
   if (!partialStepState || !partialStepState.name) return state;
@@ -49,17 +50,18 @@ export const unregisterStep = (state: FormState, name: string): FormState => {
   return newState;
 };
 
-export const resetForm = (state: FormState): FormState => {
+export const resetForm = (state: FormState, resetOptions: ResetOptions = {}): FormState => {
   const newState = {
     ...state,
-    resetKey: state.resetKey + 1,
-    isSubmitted: false,
-    isValid: true,
-    navigatedStepName: null,
+    resetKey: isResetAllowed('resetKey', resetOptions) ? state.resetKey + 1 : state.resetKey,
+    isSubmitted: isResetAllowed('submitted', resetOptions) ? false : state.isPristine,
+    isPristine: isResetAllowed('pristine', resetOptions) ? true : state.isPristine,
+    navigatedStepName: isResetAllowed('currentStep', resetOptions) ? null : state.navigatedStepName,
     steps: state.steps.map((step) => ({
       ...step,
-      isSubmitted: false,
-      isVisited: false,
+      isSubmitted: isResetAllowed('submitted', resetOptions) ? false : step.isSubmitted,
+      isPristine: isResetAllowed('pristine', resetOptions) ? true : step.isPristine,
+      isVisited: isResetAllowed('visited', resetOptions) ? false : step.isVisited,
     })),
   };
   return newState;

--- a/packages/core/src/types/form.types.ts
+++ b/packages/core/src/types/form.types.ts
@@ -30,6 +30,19 @@ export type FromSetFieldsValues = {
 
 export type FormValues = any;
 
+export type ResetElement =
+  | 'pristine'
+  | 'submitted'
+  | 'validating'
+  | 'resetKey'
+  | 'currentStep'
+  | 'visited'
+  | 'values';
+
+export type ResetOptions = {
+  only?: ResetElement[],
+  exclude?: ResetElement[],
+}
 export interface FormContextValue {
   formStateRef?: React.RefObject<FormState>;
   fieldsRef?: React.RefObject<FormFields>;
@@ -70,7 +83,7 @@ export interface FormMethods {
   goToStep(stepName: string): void;
   nextStep(): void;
   prevStep(): void;
-  reset(): void;
+  reset(options?: ResetOptions): void;
   __connect__?(s: any): void;
 }
 

--- a/packages/core/src/useField.ts
+++ b/packages/core/src/useField.ts
@@ -11,10 +11,10 @@ import {
   FieldAsyncValidationObject,
   fieldDefaultProps,
 } from './types/field.types';
-import { FormFields } from './types/form.types';
+import { FormFields, ResetOptions } from './types/form.types';
 import { ErrorFieldWithoutForm, ErrorFieldWithoutName } from './errors';
 import {
-  getFieldUniqueId, useRefValue, getExposedField,
+  getFieldUniqueId, useRefValue, getExposedField, isResetAllowed,
 } from './utils';
 import { useFormContext, defaultFormState } from './Formiz';
 import { useStepContext } from './FormizStep';
@@ -144,26 +144,28 @@ export const useField = ({
   useEffect(() => {
     const subscription = subjectsRef.current.onReset
       .subscription
-      .subscribe(() => {
+      .subscribe((resetOptions: ResetOptions = {}) => {
+        console.log(resetOptions);
+
         const value = get(initialValuesRef?.current, nameRef.current) ?? defaultValueRef.current;
 
         setState((prevState) => ({
           ...prevState,
-          externalErrors: [],
-          resetKey: prevState.resetKey + 1,
-          isPristine: true,
-          isValidating: false,
-          value,
+          externalErrors: isResetAllowed('values', resetOptions) ? [] : prevState.externalErrors,
+          resetKey: isResetAllowed('resetKey', resetOptions) ? prevState.resetKey + 1 : prevState.resetKey,
+          isPristine: isResetAllowed('pristine', resetOptions) ? true : prevState.isPristine,
+          isValidating: isResetAllowed('validating', resetOptions) ? false : prevState.isValidating,
+          value: isResetAllowed('values', resetOptions) ? value : prevState.value,
         }));
 
-        onChangeRef.current(
-          formatValueRef.current(value),
-          value,
-        );
-
-        if (actionsRef.current?.removeFromInitialValues) {
-          actionsRef.current.removeFromInitialValues(nameRef.current);
+        if (isResetAllowed('values', resetOptions)) {
+          onChangeRef.current(
+            formatValueRef.current(value),
+            value,
+          );
+          actionsRef.current?.removeFromInitialValues?.(nameRef.current);
         }
+
       });
     return () => subscription.unsubscribe();
   }, [

--- a/packages/core/src/utils/form.utils.ts
+++ b/packages/core/src/utils/form.utils.ts
@@ -1,6 +1,6 @@
 import { ExposedField, Field } from 'types/field.types';
 import { StepState } from 'types/step.types';
-import { FormFields, FormState } from 'types/form.types';
+import { FormFields, FormState, ResetElement, ResetOptions } from 'types/form.types';
 import { getFieldHtmlUniqueId } from './global.utils';
 
 const isObject = (x: any) => x && typeof x === 'object' && x.constructor === Object;
@@ -115,3 +115,7 @@ export const getFormFields = (fields: FormFields, formState: FormState) => {
 
   return parseValues(exposedFields);
 };
+
+export const isResetAllowed = (resetElement: ResetElement, resetOptions: ResetOptions) =>
+  (!resetOptions.only || resetOptions.only.includes(resetElement))
+  && (!resetOptions.exclude || !resetOptions.exclude.includes(resetElement));

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,6 +1,4 @@
-export {
-  getFormFields, getFormValues, getFormFlatValues, getExposedField,
-} from './form.utils';
-export { getFormUniqueId, getFieldUniqueId, getFieldHtmlUniqueId } from './global.utils';
-export { useRefValue } from './useRefValue';
-export { useSubject, useBehaviorSubject } from './useSubject';
+export * from './form.utils';
+export * from './global.utils';
+export * from './useRefValue';
+export * from './useSubject';

--- a/packages/core/src/utils/useSubject.ts
+++ b/packages/core/src/utils/useSubject.ts
@@ -2,26 +2,31 @@ import React, { useRef } from 'react';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { throttleTime } from 'rxjs/operators';
 
-export const useSubject = (valueRef: React.RefObject<any>, throttle = 100) => {
+export const useSubject = (valueRef?: React.RefObject<any>, throttle = 100) => {
   const subjectRef = useRef(new Subject());
   const push = (value?: any) => {
-    subjectRef.current.next(value ?? valueRef.current);
+    subjectRef.current.next(value ?? valueRef?.current);
   };
 
-  const subscription = subjectRef.current
-    .pipe(throttleTime(throttle, undefined, { leading: true, trailing: true }));
+  const subscription = subjectRef.current.pipe(
+    throttleTime(throttle, undefined, { leading: true, trailing: true }),
+  );
 
   return { push, subscription };
 };
 
-export const useBehaviorSubject = (valueRef: React.RefObject<any>, throttle = 100) => {
+export const useBehaviorSubject = (
+  valueRef: React.RefObject<any>,
+  throttle = 100,
+) => {
   const subjectRef = useRef(new BehaviorSubject(valueRef.current));
   const push = (value?: any) => {
     subjectRef.current.next(value ?? valueRef.current);
   };
 
-  const subscription = subjectRef.current
-    .pipe(throttleTime(throttle, undefined, { leading: true, trailing: true }));
+  const subscription = subjectRef.current.pipe(
+    throttleTime(throttle, undefined, { leading: true, trailing: true }),
+  );
 
   return { push, subscription };
 };


### PR DESCRIPTION
New feature for partial reseting.

### reset(options)

#### Options

Available reset elements for the `only` and `exclude` options.
```js
'pristine'    // Reset isPristine state for form, steps & fields
'submitted'   // Reset isSubmitted state for form, steps & fields
'validating'  // Reset isValidating state for form, steps & fields
'resetKey'    // Increment the resetKey
'currentStep' // Reset the currentStep
'visited'     // Reset isVisited state for steps
'values'      // Reset all fields values
```

##### only

Allows to reset only some elements.

```js
// Reset only pristine state and submitted state
form.reset({ only: ['pristine', 'submitted'] });
```

##### exclude

Allows to prevent reseting some elements.

```js
// Reset everything except the form values
form.reset({ exclude: ['values'] });
```