### PR TITLE
Fix: delete resetOptions console.log on useField

### DIFF
--- a/packages/core/src/useField.ts
+++ b/packages/core/src/useField.ts
@@ -145,7 +145,6 @@ export const useField = ({
     const subscription = subjectsRef.current.onReset
       .subscription
       .subscribe((resetOptions: ResetOptions = {}) => {
-        console.log(resetOptions);
 
         const value = get(initialValuesRef?.current, nameRef.current) ?? defaultValueRef.current;
 


### PR DESCRIPTION
A wild `console.log` appears with 1.6.0 release
![Capture d’écran 2021-10-19 à 22 45 06](https://user-images.githubusercontent.com/48803115/137988218-86a9a748-e598-4152-8017-2980d5a18eb4.png)
