### PR TITLE
Link for formiz v2

### DIFF
--- a/documentation/src/pages/index.js
+++ b/documentation/src/pages/index.js
@@ -170,15 +170,17 @@ function Home() {
               Demos
             </Link>
           </div>
-          <Link
+          <a
             className={classnames(
               'button button--link button--md text-white underline transition duration-700 ease-in-out hover:no-underline hover:text-green-100',
               styles.getStarted,
             )}
-            to={useBaseUrl('https://github.com/ivan-dalmet/formiz/issues/116')}
+            href="https://github.com/ivan-dalmet/formiz/issues/116"
+            target="_blank"
+            rel="noreferrer"
           >
             Formiz v2 is under construction !
-          </Link>
+          </a>
         </div>
       </header>
       <main>

--- a/documentation/src/pages/index.js
+++ b/documentation/src/pages/index.js
@@ -179,7 +179,7 @@ function Home() {
             target="_blank"
             rel="noopener noreferrer"
           >
-            Formiz v2 is under construction !
+            Formiz v2 is under construction!
           </a>
         </div>
       </header>

--- a/documentation/src/pages/index.js
+++ b/documentation/src/pages/index.js
@@ -177,7 +177,7 @@ function Home() {
             )}
             href="https://github.com/ivan-dalmet/formiz/issues/116"
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
           >
             Formiz v2 is under construction !
           </a>

--- a/documentation/src/pages/index.js
+++ b/documentation/src/pages/index.js
@@ -170,6 +170,15 @@ function Home() {
               Demos
             </Link>
           </div>
+          <Link
+            className={classnames(
+              'button button--link button--md text-white underline transition duration-700 ease-in-out hover:no-underline hover:text-green-100',
+              styles.getStarted,
+            )}
+            to={useBaseUrl('https://github.com/ivan-dalmet/formiz/issues/116')}
+          >
+            Formiz v2 is under construction !
+          </Link>
         </div>
       </header>
       <main>


### PR DESCRIPTION
added a small link to the issue that announce formiz v2 in the hero of formiz landing page, configured the link's style and hover effect.
<img width="1426" alt="image" src="https://user-images.githubusercontent.com/45878945/165524856-7a050856-7b6d-4960-bb9b-d6027cd2ef01.png">
