### PR TITLE
V2 - useForm actions: add form param 

### DIFF
--- a/apps/docs/src/pages/migration.mdx
+++ b/apps/docs/src/pages/migration.mdx
@@ -103,11 +103,9 @@ const MyChildren = () => {
 
 ```tsx filename="Formiz V2"
 const MyForm = () => {
-  const handleSubmit = (values) => {
+  const form = useForm({ onSubmit: (values) => { // ✅ Form values passed in useForm
     console.log({ values })
-  } 
-
-  const form = useForm({ onSubmit: handleSubmit }); // ✅ Form values passed in useForm
+  }}); 
 
   const values = useFormFields({
     connect: form,

--- a/apps/examples/src/pages/async-initial-values.tsx
+++ b/apps/examples/src/pages/async-initial-values.tsx
@@ -10,16 +10,10 @@ import { isEmail } from "@formiz/validations";
 import { NextPage } from "next";
 import { useEffect, useState } from "react";
 
+type FormValues = any;
+
 const SimpleForm: NextPage = () => {
   const toastValues = useToastValues();
-
-  const handleSubmit = (values: any) => {
-    toastValues(values);
-
-    form.setErrors({
-      name: "You can display an error after an API call",
-    });
-  };
 
   const [data, setData] = useState();
   const [isFetched, setIsFetched] = useState(false);
@@ -34,10 +28,15 @@ const SimpleForm: NextPage = () => {
     dataFetch();
   }, []);
 
-  const form = useForm({
+  const form = useForm<FormValues>({
     ready: isFetched,
     initialValues: data,
-    onValidSubmit: handleSubmit,
+    onValidSubmit: (values, form) => {
+      toastValues(values);
+      form.setErrors({
+        name: "You can display an error after an API call",
+      });
+    },
   });
 
   return (

--- a/apps/examples/src/pages/collection.tsx
+++ b/apps/examples/src/pages/collection.tsx
@@ -27,16 +27,16 @@ const INITIAL_VALUES = {
   ],
 };
 
+type FormValues = any;
+
 const Collection = () => {
   const toastValues = useToastValues();
 
-  const handleSubmit = (values: any) => {
-    toastValues(values);
-  };
-
-  const form = useForm({
-    onValidSubmit: handleSubmit,
+  const form = useForm<FormValues>({
     initialValues: INITIAL_VALUES,
+    onValidSubmit: (values) => {
+      toastValues(values);
+    },
   });
 
   const collection = useCollection({

--- a/apps/examples/src/pages/dynamic-steps.tsx
+++ b/apps/examples/src/pages/dynamic-steps.tsx
@@ -15,15 +15,15 @@ type FormValues = {};
 const DynamicSteps = () => {
   const toastValues = useToastValues();
 
-  const handleSubmit = (values: FormValues) => {
-    toastValues(values);
+  const form = useForm<FormValues>({
+    onValidSubmit: (values, form) => {
+      toastValues(values);
 
-    form.setErrors({
-      name: "You can display an error after an API call",
-    });
-  };
-
-  const form = useForm({ onValidSubmit: handleSubmit });
+      form.setErrors({
+        name: "You can display an error after an API call",
+      });
+    },
+  });
   const values = useFormFields({
     connect: form,
     fields: ["count"],

--- a/apps/examples/src/pages/exotic-fields.tsx
+++ b/apps/examples/src/pages/exotic-fields.tsx
@@ -8,19 +8,19 @@ import { Formiz, useForm } from "@formiz/core";
 import { isMaxNumber, isMinNumber } from "@formiz/validations";
 import { NextPage } from "next";
 
+type FormValues = any;
+
 const ExoticFields: NextPage = () => {
   const toastValues = useToastValues();
 
-  const handleSubmit = (values: any) => {
-    toastValues(values);
+  const form = useForm<FormValues>({
+    onValidSubmit: (values, form) => {
+      toastValues(values);
 
-    form.setErrors({
-      name: "You can display an error after an API call",
-    });
-  };
-
-  const form = useForm({
-    onValidSubmit: handleSubmit,
+      form.setErrors({
+        name: "You can display an error after an API call",
+      });
+    },
     onValuesChange: console.log,
   });
 

--- a/apps/examples/src/pages/index.tsx
+++ b/apps/examples/src/pages/index.tsx
@@ -9,20 +9,20 @@ import { Formiz, useForm, useFormFields } from "@formiz/core";
 import { isEmail } from "@formiz/validations";
 import { NextPage } from "next";
 
+type FormValues = any;
+
 const SimpleForm: NextPage = () => {
   const toastValues = useToastValues();
 
-  const handleSubmit = (values: any) => {
-    toastValues(values);
-
-    form.setErrors({
-      name: "You can display an error after an API call",
-    });
-  };
-
-  const form = useForm({
+  const form = useForm<FormValues>({
     initialValues: { company: "My Company" },
-    onValidSubmit: handleSubmit,
+    onValidSubmit: (values, form) => {
+      toastValues(values);
+
+      form.setErrors({
+        name: "You can display an error after an API call",
+      });
+    },
     onValuesChange: console.log,
     onValid: () => console.log("onValid"),
     onInvalid: () => console.log("onInvalid"),

--- a/apps/examples/src/pages/lot-of-fields.tsx
+++ b/apps/examples/src/pages/lot-of-fields.tsx
@@ -13,20 +13,20 @@ const FIELDS_BY_STEP = 20;
 const Wizard: NextPage = () => {
   const toastValues = useToastValues();
 
-  const handleSubmit = (values: Record<string, string>) => {
-    toastValues(values);
+  const form = useForm<Record<string, string>>({
+    onValidSubmit: (values, form) => {
+      toastValues(values);
 
-    form.setErrors({
-      "user[0].name": "You can display an error after an API call",
-    });
+      form.setErrors({
+        "user[0].name": "You can display an error after an API call",
+      });
 
-    const stepWithError = form.getStepByFieldName("user[0].name");
-    if (stepWithError) {
-      form.goToStep(stepWithError.name);
-    }
-  };
-
-  const form = useForm({ onValidSubmit: handleSubmit });
+      const stepWithError = form.getStepByFieldName("user[0].name");
+      if (stepWithError) {
+        form.goToStep(stepWithError.name);
+      }
+    },
+  });
 
   return (
     <Formiz connect={form} autoForm="step">

--- a/apps/examples/src/pages/nested-forms.tsx
+++ b/apps/examples/src/pages/nested-forms.tsx
@@ -23,18 +23,20 @@ type FieldSubFormProps = FieldProps<string> & {
   label: string;
 };
 
+type SubFormValues = any;
+
 const FieldSubForm: FC<FieldSubFormProps> = (props) => {
   const { label } = props;
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const { setValue, value, errorMessage, isValid } = useField(props);
 
-  const handleSubmit = ({ firstName, lastName }: any) => {
-    setValue([firstName, lastName].join(" "));
-    onClose();
-  };
-
-  const subForm = useForm({ onValidSubmit: handleSubmit });
+  const subForm = useForm<SubFormValues>({
+    onValidSubmit: ({ firstName, lastName }) => {
+      setValue([firstName, lastName].join(" "));
+      onClose();
+    },
+  });
 
   const isSubmitDisabled = !subForm.isValid && subForm.isSubmitted;
 
@@ -96,12 +98,10 @@ const FieldSubForm: FC<FieldSubFormProps> = (props) => {
   );
 };
 
-const NestedForms = () => {
-  const handleSubmit = (values: any) => {
-    console.log(values);
-  };
+type FormValues = any;
 
-  const form = useForm({ onValidSubmit: handleSubmit });
+const NestedForms = () => {
+  const form = useForm<FormValues>({ onValidSubmit: console.log });
 
   return (
     <Formiz connect={form} autoForm>

--- a/apps/examples/src/pages/real-life-1.tsx
+++ b/apps/examples/src/pages/real-life-1.tsx
@@ -25,8 +25,17 @@ const RealLife1: NextPage = () => {
     }
   };
 
-  const form = useForm({
-    onValidSubmit: handleSubmit,
+  const form = useForm<FormValues>({
+    onValidSubmit: (values, form) => {
+      toastValues(values);
+      form.setErrors({
+        "docker.image": "You can display an error after an API call",
+      });
+      const stepWithError = form.getStepByFieldName("docker.image");
+      if (stepWithError) {
+        form.goToStep(stepWithError.name);
+      }
+    },
     onValuesChange: console.log,
   });
 

--- a/apps/examples/src/pages/steppers.tsx
+++ b/apps/examples/src/pages/steppers.tsx
@@ -40,7 +40,19 @@ const Steppers = () => {
     }
   };
 
-  const form = useForm({ onValidSubmit: handleSubmit });
+  const form = useForm<FormValues>({
+    onValidSubmit: (values, form) => {
+      toastValues(values);
+
+      form.setErrors({
+        name: "You can display an error after an API call",
+      });
+      const stepWithError = form.getStepByFieldName("name");
+      if (stepWithError) {
+        form.goToStep(stepWithError?.name);
+      }
+    },
+  });
 
   return (
     <Formiz connect={form} autoForm="step">

--- a/apps/examples/src/pages/wizard.tsx
+++ b/apps/examples/src/pages/wizard.tsx
@@ -10,6 +10,8 @@ import { useState } from "react";
 
 const fakeDelay = (delay = 500) => new Promise((r) => setTimeout(r, delay));
 
+type FormValues = any;
+
 const Wizard: NextPage = () => {
   const [status, setStatus] = useState("idle");
 
@@ -38,27 +40,24 @@ const Wizard: NextPage = () => {
     form.submitStep();
   };
 
-  /**
-   * Handle the complete form submit
-   */
-  const handleSubmit = async (values: any) => {
-    setStatus("loading");
-    console.log("Submitting form...", values); // eslint-disable-line no-console
-    await fakeDelay();
-    setStatus("success");
+  const form = useForm<FormValues>({
+    onValidSubmit: async (values, form) => {
+      setStatus("loading");
+      console.log("Submitting form...", values); // eslint-disable-line no-console
+      await fakeDelay();
+      setStatus("success");
 
-    toastValues(values);
+      toastValues(values);
 
-    form.setErrors({
-      name: "You can display an error after an API call",
-    });
-    const stepWithError = form.getStepByFieldName("name");
-    if (stepWithError) {
-      form.goToStep(stepWithError.name);
-    }
-  };
-
-  const form = useForm({ onValidSubmit: handleSubmit });
+      form.setErrors({
+        name: "You can display an error after an API call",
+      });
+      const stepWithError = form.getStepByFieldName("name");
+      if (stepWithError) {
+        form.goToStep(stepWithError.name);
+      }
+    },
+  });
   const isLoading = status === "loading" || form.isValidating;
 
   return (

--- a/packages/formiz-core/src/selectors.ts
+++ b/packages/formiz-core/src/selectors.ts
@@ -85,6 +85,8 @@ export const formInterfaceSelector = (state: Store) => {
     isLastStep: state.steps.at(-1)?.name === currentStep?.name,
   };
 };
+export interface FormInterface
+  extends ReturnType<typeof formInterfaceSelector> {}
 
 export const stepInterfaceSelector = (state: Store) => (step: Step) => {
   return {

--- a/packages/formiz-core/src/store.ts
+++ b/packages/formiz-core/src/store.ts
@@ -22,6 +22,7 @@ import type {
   StoreInitialState,
 } from "@/types";
 import uniqid from "uniqid";
+import { formInterfaceSelector } from "@/selectors";
 
 export const createStore = (defaultState?: StoreInitialState) =>
   create<Store>()((set, get) => ({
@@ -78,11 +79,20 @@ export const createStore = (defaultState?: StoreInitialState) =>
         const formValues = getFormValues(fields);
 
         if (getFormIsValid(fields)) {
-          formConfigRef.current?.onValidSubmit?.(formValues);
+          formConfigRef.current?.onValidSubmit?.(
+            formValues,
+            formInterfaceSelector(get())
+          );
         } else {
-          formConfigRef.current?.onInvalidSubmit?.(formValues);
+          formConfigRef.current?.onInvalidSubmit?.(
+            formValues,
+            formInterfaceSelector(get())
+          );
         }
-        formConfigRef.current?.onSubmit?.(formValues);
+        formConfigRef.current?.onSubmit?.(
+          formValues,
+          formInterfaceSelector(get())
+        );
       },
 
       setValues: (newValues, { keepPristine = false } = {}) => {

--- a/packages/formiz-core/src/tests/store/submitForm.test.ts
+++ b/packages/formiz-core/src/tests/store/submitForm.test.ts
@@ -1,3 +1,4 @@
+import { formInterfaceSelector } from "@/selectors";
 import { createStore } from "@/store";
 import { generateField } from "@/utils/form";
 
@@ -33,10 +34,13 @@ describe("submitForm", () => {
     store.getState().actions.submitForm();
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
-    expect(onSubmit).toHaveBeenCalledWith({
-      fieldA: "valueA",
-      nested: { fieldB: "valueB" },
-    });
+    expect(onSubmit).toHaveBeenCalledWith(
+      {
+        fieldA: "valueA",
+        nested: { fieldB: "valueB" },
+      },
+      expect.anything()
+    );
   });
 
   it("Should not submit if on field is validating", () => {

--- a/packages/formiz-core/src/types.ts
+++ b/packages/formiz-core/src/types.ts
@@ -1,3 +1,4 @@
+import { FormInterface } from "@/selectors";
 import React, { FormEvent, RefObject } from "react";
 import { StoreApi, UseBoundStore } from "zustand";
 
@@ -250,12 +251,12 @@ export interface useFormProps<Values = unknown> {
   initialValues?: Partial<Values>;
   initialStepName?: string;
   ready?: boolean;
-  onValuesChange?(values: Values): void;
-  onSubmit?(values: Values): void;
-  onValidSubmit?(values: Values): void;
-  onInvalidSubmit?(values: Values): void;
-  onValid?(): void;
-  onInvalid?(): void;
+  onValuesChange?(values: Values, form: FormInterface): void;
+  onSubmit?(values: Values, form: FormInterface): void;
+  onValidSubmit?(values: Values, form: FormInterface): void;
+  onInvalidSubmit?(values: Values, form: FormInterface): void;
+  onValid?(form: FormInterface): void;
+  onInvalid?(form: FormInterface): void;
 }
 
 export interface FormizProps {

--- a/packages/formiz-core/src/useForm.tsx
+++ b/packages/formiz-core/src/useForm.tsx
@@ -80,7 +80,10 @@ const useOnValuesChange = (useStore?: UseBoundStore<StoreApi<Store>>) => {
     timeoutRef.current = setTimeout(() => {
       const formValues = getFormValues(state.fields);
       if (deepEqual(formValues, prevFormValuesRef.current)) return;
-      state.formConfigRef.current?.onValuesChange?.(formValues);
+      state.formConfigRef.current?.onValuesChange?.(
+        formValues,
+        formInterfaceSelector(state)
+      );
       prevFormValuesRef.current = formValues;
     });
     return null;
@@ -108,7 +111,7 @@ const useIsValidChange = (useStore?: UseBoundStore<StoreApi<Store>>) => {
       const action = isValid
         ? state.formConfigRef.current?.onValid
         : state.formConfigRef.current?.onInvalid;
-      action?.();
+      action?.(formInterfaceSelector(state));
       prevIsValidRef.current = isValid;
     });
     return null;

--- a/packages/formiz-core/src/useFormContext.tsx
+++ b/packages/formiz-core/src/useFormContext.tsx
@@ -1,14 +1,14 @@
 import { deepEqual } from "fast-equals";
 
 import { useFormStore } from "@/Formiz";
-import { formInterfaceSelector } from "@/selectors";
+import { FormInterface, formInterfaceSelector } from "@/selectors";
 import { ERROR_USE_FORM_CONTEXT_MISSING_CONTEXT } from "@/errors";
 
-export const useFormContext = () => {
+export const useFormContext = (): FormInterface => {
   const { useStore } = useFormStore() ?? {};
   if (!useStore) {
     throw new Error(ERROR_USE_FORM_CONTEXT_MISSING_CONTEXT);
   }
   const formState = useStore?.(formInterfaceSelector, deepEqual);
-  return { ...formState } as const;
+  return { ...formState };
 };


### PR DESCRIPTION
Add form as second argument of useForm actions props, that allows to use form actions on submit for example.

Example :
```ts
const form = useForm<FormValues>({ onSubmit: (values, form) => {
  ...
  form.setErrors({ ... });
}
```