### PR TITLE
V2.0: Fix reset field with validations deps

### DIFF
--- a/apps/examples/cypress/e2e/simple-form.cy.ts
+++ b/apps/examples/cypress/e2e/simple-form.cy.ts
@@ -7,6 +7,7 @@ describe("Simple Form", () => {
   it("Simple Case", () => {
     cy.field("name").fill("John");
     cy.field("email").fill("john@company.com");
+    cy.field("confirmEmail").fill("john@company.com");
     cy.wait(1000);
     cy.formSubmit();
     cy.isFormSuccess();
@@ -27,6 +28,7 @@ describe("Simple Form", () => {
   it("Set fields errors", () => {
     cy.field("name").fill("John");
     cy.field("email").fill("john@company.com");
+    cy.field("confirmEmail").fill("john@company.com");
 
     cy.wait(1000);
     cy.formSubmit();
@@ -43,5 +45,30 @@ describe("Simple Form", () => {
     cy.wait(1000);
     cy.field("name").hasValue("John");
     cy.field("email").hasValue("john@company.com");
+  });
+
+  it("Update validations deps", () => {
+    cy.field("name").fill("John");
+    cy.field("email").fill("john@company.com");
+    cy.field("confirmEmail").fill("john@company.com");
+
+    cy.wait(1000);
+    cy.formSubmit();
+    cy.isFormSuccess();
+
+    cy.wait(100);
+
+    cy.field("email").fill("update");
+    cy.field("confirmEmail").hasError("Emails are not equals");
+  });
+
+  it("Reset form when field with validations deps", () => {
+    cy.field("email").fill("john@company.com");
+    cy.field("confirmEmail").fill("email");
+
+    cy.get("button").contains("Reset form").click();
+
+    cy.field("email").hasValue("");
+    cy.field("confirmEmail").hasValue("");
   });
 });

--- a/apps/examples/src/pages/index.tsx
+++ b/apps/examples/src/pages/index.tsx
@@ -28,9 +28,9 @@ const SimpleForm: NextPage = () => {
     onInvalid: () => console.log("onInvalid"),
   });
 
-  const { accountType } = useFormFields({
+  const { accountType, email } = useFormFields({
     connect: form,
-    fields: ["accountType"],
+    fields: ["accountType", "email"],
     selector: (f) => f.value,
   });
 
@@ -78,6 +78,32 @@ const SimpleForm: NextPage = () => {
               onClick={() =>
                 form.setValues({
                   email: "john@company.com",
+                })
+              }
+            >
+              Fill with john@company.com
+            </Button>
+          </FieldInput>
+          <FieldInput
+            name="confirmEmail"
+            label="Confirm email"
+            type="email"
+            formatValue={(val) => (val || "").trim()}
+            required="Required"
+            validations={[
+              {
+                handler: (value) => value === email,
+                message: "Emails are not equals",
+                deps: [email],
+              },
+            ]}
+          >
+            <Button
+              size="sm"
+              variant="link"
+              onClick={() =>
+                form.setValues({
+                  confirmEmail: "john@company.com",
                 })
               }
             >

--- a/packages/formiz-core/src/store.ts
+++ b/packages/formiz-core/src/store.ts
@@ -23,6 +23,7 @@ import type {
 } from "@/types";
 import uniqid from "uniqid";
 import { formInterfaceSelector } from "@/selectors";
+import { getFieldValidationsErrors } from "@/utils/validations";
 
 export const createStore = (defaultState?: StoreInitialState) =>
   create<Store>()((set, get) => ({
@@ -102,7 +103,7 @@ export const createStore = (defaultState?: StoreInitialState) =>
             const newValue = lodashGet(externalValues, field.name);
             if (newValue !== undefined) {
               const { requiredErrors, validationsErrors } =
-                get().actions.getFieldValidationsErrors(
+                getFieldValidationsErrors(
                   newValue,
                   newValue,
                   field.requiredRef?.current,
@@ -172,7 +173,7 @@ export const createStore = (defaultState?: StoreInitialState) =>
 
             // Validations
             const { requiredErrors, validationsErrors } =
-              get().actions.getFieldValidationsErrors(
+              getFieldValidationsErrors(
                 resetValue,
                 resetValueFormatted,
                 field.requiredRef?.current,
@@ -260,32 +261,6 @@ export const createStore = (defaultState?: StoreInitialState) =>
         });
       },
 
-      getFieldValidationsErrors: (
-        value,
-        formattedValue,
-        required,
-        validations
-      ) => {
-        // Required
-        const requiredErrors =
-          !!required && !formattedValue && formattedValue !== 0
-            ? [required !== true ? required : undefined]
-            : [];
-
-        // Sync Validations
-        const validationsErrors = (validations ?? [])
-          .filter(
-            (validation) =>
-              (validation.checkFalsy ||
-                !!formattedValue ||
-                formattedValue === 0) &&
-              !validation.handler(formattedValue, value)
-          )
-          .map(({ message }) => message);
-
-        return { requiredErrors, validationsErrors };
-      },
-
       // FIELDS
       registerField: (
         fieldId,
@@ -341,7 +316,7 @@ export const createStore = (defaultState?: StoreInitialState) =>
           const formattedValue = formatValue(value as any);
 
           const { requiredErrors, validationsErrors } =
-            get().actions.getFieldValidationsErrors(
+            getFieldValidationsErrors(
               value,
               formattedValue,
               requiredRef?.current,
@@ -427,7 +402,7 @@ export const createStore = (defaultState?: StoreInitialState) =>
 
             // Validations
             const { requiredErrors, validationsErrors } =
-              get().actions.getFieldValidationsErrors(
+              getFieldValidationsErrors(
                 value,
                 formattedValue,
                 field.requiredRef?.current,

--- a/packages/formiz-core/src/types.ts
+++ b/packages/formiz-core/src/types.ts
@@ -163,13 +163,6 @@ export interface Store {
     reset(options?: ResetOptions): void;
     resetInitialValues(): void;
 
-    getFieldValidationsErrors<Value>(
-      value: Value,
-      formattedValue: Value,
-      required: FieldProps<Value>["required"],
-      validations: FieldProps<Value>["validations"]
-    ): { requiredErrors: ErrorMessage[]; validationsErrors: ErrorMessage[] };
-
     registerField<Value>(
       fieldId: string,
       newField: PartialField<Value> & Pick<Field<Value>, "name">,

--- a/packages/formiz-core/src/useField.ts
+++ b/packages/formiz-core/src/useField.ts
@@ -27,6 +27,7 @@ import {
   ERROR_USE_FIELD_MISSING_NAME,
   ERROR_USE_FIELD_MISSING_PROPS,
 } from "./errors";
+import { getFieldValidationsErrors } from "@/utils/validations";
 
 export const useField = <
   Props extends FieldProps<any> = FieldProps<any>,
@@ -325,13 +326,26 @@ export const useField = <
   const validationsDepsPrevRef = useRef(validationsDeps);
 
   useEffect(() => {
-    if (
-      (deferredValue !== undefined && deferredValue !== valueRef.current) ||
-      validationsDepsPrevRef.current !== validationsDeps
-    ) {
+    if (deferredValue !== undefined && deferredValue !== valueRef.current) {
       setFieldValue(deferredValue);
     }
-  }, [deferredValue, setFieldValue, validationsDeps]);
+  }, [deferredValue, setFieldValue]);
+
+  useEffect(() => {
+    if (validationsDepsPrevRef.current !== validationsDeps) {
+      const currentField = useStore.getState().fields.get(fieldIdRef.current);
+      const { requiredErrors, validationsErrors } = getFieldValidationsErrors(
+        currentField?.value,
+        currentField?.formattedValue,
+        currentField?.requiredRef?.current,
+        currentField?.validationsRef?.current
+      );
+      storeActions.updateField(fieldIdRef.current, {
+        requiredErrors,
+        validationsErrors,
+      });
+    }
+  }, [storeActions, validationsDeps, useStore]);
 
   const externalProcessing = {
     start: () =>

--- a/packages/formiz-core/src/utils/validations.ts
+++ b/packages/formiz-core/src/utils/validations.ts
@@ -1,0 +1,24 @@
+import { FieldProps } from "@/types";
+
+export const getFieldValidationsErrors = <Value>(
+  value: Value,
+  formattedValue: Value,
+  required: FieldProps<Value>["required"],
+  validations: FieldProps<Value>["validations"]
+) => {
+  const requiredErrors =
+    !!required && !formattedValue && formattedValue !== 0
+      ? [required !== true ? required : undefined]
+      : [];
+
+  // Sync Validations
+  const validationsErrors = (validations ?? [])
+    .filter(
+      (validation) =>
+        (validation.checkFalsy || !!formattedValue || formattedValue === 0) &&
+        !validation.handler(formattedValue, value)
+    )
+    .map(({ message }) => message);
+
+  return { requiredErrors, validationsErrors };
+};


### PR DESCRIPTION
Fix an issue where a field with validations with deps were not reset on form reset.

- Add the use case on simple form
- Fix bug moving validations calculation on deps update in a separated useEffect
- Move utils getFieldValidationsErrors from store to utils folder
- Add tests